### PR TITLE
Info on error during apt-key addition

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -145,6 +145,11 @@ How can I change on-chain settings without deleting the blockchain?
 Use the ``sawset`` command. This allows you to change settings such
 as maximum batches per block or target wait time.
 
+I got error ``gpg: keyserver receive failed: keyserver error`` when executing ``sudo apt-key adv --keyserver hkp://keyserver...``
+------------------------------
+This error means your machine couldn't add the supplied key to trusted list. This key is later used to authenticate and get sawtooth package.
+One of the possible reason for this error is that your machine is trying to connect to keyserver through a proxy server. Add proxy server details in the command to solve this issue. For examople, ``sudo apt-key adv --keyserver-options http-proxy=http://[username:password]@<proxyserver>:<port> --keyserver hkp://keyse...`` (notice usage of flag ``--keyserver-options`` here).
+
 What does this error mean ``repository ... xenial InRelease' doesn't support architecture 'i386'``?
 ---------------------------
 Following could be possibilities:


### PR DESCRIPTION
If the machine is behind proxy server, apt-key addition will fail.
Command for addition of apt-key needs to be changed to include
the proxy server information in it.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>